### PR TITLE
[DGS-609] Fix a form validation regression

### DIFF
--- a/app/controllers/subsidy/applications/edit/step/edit.js
+++ b/app/controllers/subsidy/applications/edit/step/edit.js
@@ -171,7 +171,7 @@ export default class SubsidyApplicationsEditStepEditController extends Controlle
           sourceNode: this.sourceNode,
           store: this.formStore,
         };
-        this.isValidForm = validateForm(this.form, options);
+        this.isValidForm = await validateForm(this.form, options);
         if (!this.isValidForm) {
           this.forceShowErrors = true;
         } else {


### PR DESCRIPTION
The `validatForm` util is now async so we need to await it first. A promise is truthy so it always considered the form valid.

## ID

DGS-609

## Description

The form updates in #43 accidentally broke the form validations.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## How to test

Try to submit a form with invalid fields and verify that the error messages are displayed.
