### PR TITLE
[DL-7265] Update the Gitbook link

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,7 +5,7 @@
   <AuMainHeader @brandLink={{unless this.session.isAuthenticated "https://www.vlaanderen.be/nl" }} @homeRoute="index"
     @appTitle={{this.appTitle}}>
       <li class="au-c-list-horizontal__item au-u-hide-on-print">
-        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/handleiding-loket/veelgestelde-vragen" @skin="secondary"
+        <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/handleiding-subsidiepunt" @skin="secondary"
           @icon="question-circle">
           Help
         </AuLinkExternal>


### PR DESCRIPTION
We now link to the dedicated user manual instead of the generic loket one.