### PR TITLE
[DL-7514] Fix wrong status icon after submitting step

### DIFF
--- a/app/components/application-flow-step-link.js
+++ b/app/components/application-flow-step-link.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 
 export default class ApplicationFlowStepLinkComponent extends Component {
   @service store;
-  @tracked isFormSubmitted = false;
+  @tracked form;
 
   constructor() {
     super(...arguments);
@@ -25,9 +25,13 @@ export default class ApplicationFlowStepLinkComponent extends Component {
 
     const form = forms.at(0);
     if (form) {
-      const status = await form.status;
-      this.isFormSubmitted = status?.isSent ?? false;
+      await form.status;
+      this.form = form;
     }
+  }
+
+  get isFormSubmitted() {
+    return this.form?.get('status')?.get('isSent') ?? false;
   }
 
   get isSubmitted() {


### PR DESCRIPTION
## ID
[DL-7514](https://binnenland.atlassian.net/browse/DL-7514)

## Description

When submitting a subsidy form it would show you the wrong status icon. (gray skipped icon). This is bad user experience (they might think they did something wrong). Only after refreshing the page, it actually shows the correct status. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Other

## How to test

Setup as usual, submit any step. Without reloading, the step list item in the left sidebar should have the green checkmark and not the gray spin icon

